### PR TITLE
Revert "Bump recheck from 1.1.1 to 1.2.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 			<dependency>
 				<groupId>de.retest</groupId>
 				<artifactId>recheck</artifactId>
-				<version>1.2.0</version>
+				<version>1.1.1</version>
 			</dependency>
 			<dependency>
 				<groupId>de.retest</groupId>


### PR DESCRIPTION
This reverts commit 02ec44014423da724f6b48b6ca0502b1b8a19d22. We need recheck to stay compatible with recheck-web.