### PR TITLE
Don't allow snapshots anymore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,25 +284,4 @@
 			</plugins>
 		</pluginManagement>
 	</build>
-
-	<profiles>
-		<profile>
-			<id>allow-snapshots</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
-			<repositories>
-				<repository>
-					<id>nexus-retest</id>
-					<url>https://nexus.retest.org/repository/all/</url>
-					<releases>
-						<enabled>true</enabled>
-					</releases>
-					<snapshots>
-						<enabled>true</enabled>
-					</snapshots>
-				</repository>
-			</repositories>
-		</profile>
-	</profiles>
 </project>


### PR DESCRIPTION
This caused too much trouble (e.g. `master` build failing out of a sudden due to broken snapshot releases).